### PR TITLE
Add DpiHelper header with cstdint include

### DIFF
--- a/src/DpiHelper.h
+++ b/src/DpiHelper.h
@@ -1,0 +1,13 @@
+#ifndef DPIHELPER_H
+#define DPIHELPER_H
+
+#include <vector>
+#include <cstdint>
+
+// Basic utilities for working with display DPI.
+namespace DpiHelper {
+    // Returns true on success.
+    bool SetDPIScaling(uint32_t scalePercent, unsigned int monitorIndex = 0);
+}
+
+#endif // DPIHELPER_H


### PR DESCRIPTION
## Summary
- add `src/DpiHelper.h` with `<cstdint>` include
- attempt building using the command in `README.md`

## Testing
- `cl /EHsc src\AutoScale.cpp /link user32.lib gdi32.lib shell32.lib Advapi32.lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404c6f6e70832497a522b2378cad50